### PR TITLE
Fix metadata compatibility for OpenAI-compatible APIs

### DIFF
--- a/packages/core/src/core/openaiContentGenerator.test.ts
+++ b/packages/core/src/core/openaiContentGenerator.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Qwen
+ * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/core/src/core/openaiContentGenerator.ts
+++ b/packages/core/src/core/openaiContentGenerator.ts
@@ -161,8 +161,8 @@ export class OpenAIContentGenerator implements ContentGenerator {
     // Include metadata for OpenAI official API and compatible endpoints
     // Exclude for providers that don't support metadata (like GLM, Claude, etc.)
     return (
-      baseURL.includes('https://api.openai.com') ||
-      baseURL.includes('https://dashscope.aliyuncs.com')
+      baseURL.includes('https://api.openai.com/') ||
+      baseURL.includes('https://dashscope.aliyuncs.com/')
     );
   }
 

--- a/packages/core/src/core/openaiContentGenerator.ts
+++ b/packages/core/src/core/openaiContentGenerator.ts
@@ -160,7 +160,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
     let hostname: string | undefined;
     try {
       hostname = new URL(baseURL).hostname;
-    } catch (e) {
+    } catch (_e) {
       return false;
     }
     return (
@@ -1161,7 +1161,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
   private convertToGeminiFormat(
     openaiResponse: OpenAI.Chat.ChatCompletion,
   ): GenerateContentResponse {
-    const choice: any = openaiResponse.choices[0];
+    const choice = openaiResponse.choices[0];
     const response = new GenerateContentResponse();
 
     const parts: Part[] = [];

--- a/packages/core/src/core/openaiContentGenerator.ts
+++ b/packages/core/src/core/openaiContentGenerator.ts
@@ -161,10 +161,8 @@ export class OpenAIContentGenerator implements ContentGenerator {
     // Include metadata for OpenAI official API and compatible endpoints
     // Exclude for providers that don't support metadata (like GLM, Claude, etc.)
     return (
-      baseURL.includes('api.openai.com') ||
-      baseURL.includes('dashscope.aliyuncs.com') ||
-      baseURL.includes('qwen') 
-
+      baseURL.includes('https://api.openai.com') ||
+      baseURL.includes('https://dashscope.aliyuncs.com')
     );
   }
 

--- a/packages/core/src/core/openaiContentGenerator.ts
+++ b/packages/core/src/core/openaiContentGenerator.ts
@@ -152,6 +152,39 @@ export class OpenAIContentGenerator implements ContentGenerator {
   }
 
   /**
+   * Check if metadata should be included in the request
+   * Only include metadata for specific providers that support it
+   */
+  private shouldIncludeMetadata(): boolean {
+    const baseURL = this.client?.baseURL || '';
+    
+    // Include metadata for OpenAI official API and compatible endpoints
+    // Exclude for providers that don't support metadata (like GLM, Claude, etc.)
+    return (
+      baseURL.includes('api.openai.com') ||
+      baseURL.includes('dashscope.aliyuncs.com') ||
+      baseURL.includes('qwen') 
+
+    );
+  }
+
+  /**
+   * Build metadata object conditionally
+   * @param userPromptId The prompt ID for this request
+   * @returns metadata object if should be included, undefined otherwise
+   */
+  private buildMetadata(userPromptId: string): Record<string, string> | undefined {
+    if (!this.shouldIncludeMetadata()) {
+      return undefined;
+    }
+    
+    return {
+      sessionId: this.config.getSessionId?.() || '',
+      promptId: userPromptId,
+    };
+  }
+
+  /**
    * Check if an error is a timeout error
    */
   private isTimeoutError(error: unknown): boolean {
@@ -198,16 +231,14 @@ export class OpenAIContentGenerator implements ContentGenerator {
       // 3. Default values (lowest priority)
       const samplingParams = this.buildSamplingParameters(request);
 
+      const metadata = this.buildMetadata(userPromptId);
       const createParams: Parameters<
         typeof this.client.chat.completions.create
       >[0] = {
         model: this.model,
         messages,
         ...samplingParams,
-        metadata: {
-          sessionId: this.config.getSessionId?.(),
-          promptId: userPromptId,
-        },
+        ...(metadata && { metadata }),
       };
 
       // Enable store for GPT-5 and GPT-4o models when using metadata
@@ -323,6 +354,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
       // Build sampling parameters with clear priority
       const samplingParams = this.buildSamplingParameters(request);
 
+      const metadata = this.buildMetadata(userPromptId);
       const createParams: Parameters<
         typeof this.client.chat.completions.create
       >[0] = {
@@ -331,10 +363,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
         ...samplingParams,
         stream: true,
         stream_options: { include_usage: true },
-        metadata: {
-          sessionId: this.config.getSessionId?.(),
-          promptId: userPromptId,
-        },
+        ...(metadata && { metadata }),
       };
 
       // Enable store for GPT-5 and GPT-4 models when using metadata

--- a/packages/core/src/core/openaiContentGenerator.ts
+++ b/packages/core/src/core/openaiContentGenerator.ts
@@ -157,12 +157,15 @@ export class OpenAIContentGenerator implements ContentGenerator {
    */
   private shouldIncludeMetadata(): boolean {
     const baseURL = this.client?.baseURL || '';
-    
-    // Include metadata for OpenAI official API and compatible endpoints
-    // Exclude for providers that don't support metadata (like GLM, Claude, etc.)
+    let hostname: string | undefined;
+    try {
+      hostname = new URL(baseURL).hostname;
+    } catch (e) {
+      return false;
+    }
     return (
-      baseURL.includes('https://api.openai.com/') ||
-      baseURL.includes('https://dashscope.aliyuncs.com/')
+      hostname === 'api.openai.com' ||
+      hostname === 'dashscope.aliyuncs.com'
     );
   }
 


### PR DESCRIPTION
## Summary
- Improve OpenAI content generator metadata handling for better API compatibility
- Add conditional metadata inclusion based on provider support
- Prevent API errors with incompatible providers

## Changes
- Added shouldIncludeMetadata() method to check provider compatibility
- Added buildMetadata() method for conditional metadata construction  
- Updated both generateContent and generateContentStream methods
- Only include metadata for supported providers (OpenAI official, Dashscope/Qwen)
- Maintain backward compatibility for existing configurations

## Test plan
- [ ] Test with OpenAI official API (metadata should be included)
- [ ] Test with Dashscope/Qwen API (metadata should be included)
- [ ] Test with other providers like GLM (metadata should be excluded)
- [ ] Verify no API errors occur with unsupported providers