### PR TITLE
feat: bump @office-ai/aioncli-core version to 0.24.2

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@office-ai/aioncli-core",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Gemini CLI Core",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump `@office-ai/aioncli-core` version from 0.24.1 to 0.24.2

## Changes
- Updated package version in `packages/core/package.json`