### PR TITLE
fix(deps): pin @aws-sdk/client-bedrock-runtime to ^3.981.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23008,12 +23008,12 @@
     },
     "packages/core": {
       "name": "@office-ai/aioncli-core",
-      "version": "0.24.3",
+      "version": "0.24.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2a-js/sdk": "^0.3.7",
         "@anthropic-ai/sdk": "^0.52.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.975.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.981.0",
         "@google-cloud/logging": "^11.2.1",
         "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",
         "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@office-ai/aioncli-core",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "description": "Gemini CLI Core",
   "license": "Apache-2.0",
   "repository": {
@@ -26,7 +26,7 @@
   "dependencies": {
     "@a2a-js/sdk": "^0.3.7",
     "@anthropic-ai/sdk": "^0.52.0",
-    "@aws-sdk/client-bedrock-runtime": "^3.975.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.981.0",
     "@google-cloud/logging": "^11.2.1",
     "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",
     "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0",


### PR DESCRIPTION
## Summary

- Pins `@aws-sdk/client-bedrock-runtime` to `^3.981.0` to ensure transitive dependency `@aws-sdk/xml-builder@3.972.3+` is installed
- This guarantees `fast-xml-parser@5.3.4` is used (fixes CVE-2026-25128)
- Bumps `@office-ai/aioncli-core` version to `0.24.4`

## Related Issue

https://github.com/iOfficeAI/AionUi/issues/660

## Why This Is Needed

The previous fix (PR #28) updated the lock file, but when `@office-ai/aioncli-core@0.24.3` was published and consumed by other projects, npm resolved `@aws-sdk/client-bedrock-runtime@3.978.0` which still pulls the vulnerable `fast-xml-parser@5.2.5`.

By pinning to `^3.981.0`, we ensure the fixed dependency chain is always installed.

## Test Plan

- [x] `npm install` succeeds
- [x] `npm run build` passes
- [x] `npm ls fast-xml-parser` shows version 5.3.4