### PR TITLE
fix(core): enforce Kimi K2.5 sampling parameters

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@office-ai/aioncli-core",
-  "version": "0.24.4",
+  "version": "0.24.5",
   "description": "Gemini CLI Core",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/src/core/openaiContentGenerator.ts
+++ b/packages/core/src/core/openaiContentGenerator.ts
@@ -1921,17 +1921,23 @@ export class OpenAIContentGenerator implements ContentGenerator {
     // Some OpenAI-compatible gateways reject any temperature value other than 1 with
     // `400 invalid temperature: only 1 is allowed for this model`.
     const modelName = this.model.toLowerCase();
-    if (
-      (modelName.includes('gpt-5') ||
-        modelName.includes('gpt5') ||
-        modelName.includes('gpt-4o') ||
-        modelName.includes('gpt4o') ||
-        // Kimi K2.5 models (Moonshot) - some providers enforce temperature=1
-        modelName.includes('kimi-k2.5') ||
-        (modelName.includes('kimi') && modelName.includes('k2.5'))) &&
-      params.temperature !== undefined
-    ) {
+    const isKimiModel =
+      modelName.includes('kimi-k2.5') ||
+      (modelName.includes('kimi') && modelName.includes('k2.5'));
+    const isRestrictedModel =
+      modelName.includes('gpt-5') ||
+      modelName.includes('gpt5') ||
+      modelName.includes('gpt-4o') ||
+      modelName.includes('gpt4o') ||
+      isKimiModel;
+
+    if (isRestrictedModel) {
       params.temperature = 1.0;
+
+      // Kimi K2.5 models enforce top_p=0.95
+      if (isKimiModel) {
+        params.top_p = 0.95;
+      }
     }
 
     return params;

--- a/packages/core/src/core/openaiContentGenerator.ts
+++ b/packages/core/src/core/openaiContentGenerator.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* eslint-disable no-console */
 import type {
   CountTokensResponse,
   GenerateContentParameters,
@@ -25,7 +26,6 @@ import { toContents } from '../code_assist/converter.js';
 import { ApiResponseEvent } from '../telemetry/types.js';
 import type { Config } from '../config/config.js';
 import { safeJsonParse } from '../utils/safeJsonParse.js';
-import { debugLogger } from '../utils/debugLogger.js';
 
 // OpenAI API type definitions for logging
 interface OpenAIToolCall {
@@ -391,7 +391,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
 
       // Allow subclasses to suppress error logging for specific scenarios
       if (!this.shouldSuppressErrorLogging(error, request)) {
-        debugLogger.error('OpenAI API Error:', errorMessage);
+        console.error('OpenAI API Error:', errorMessage);
       }
 
       // Provide helpful timeout-specific error message
@@ -642,7 +642,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
 
       // Allow subclasses to suppress error logging for specific scenarios
       if (!this.shouldSuppressErrorLogging(error, request)) {
-        debugLogger.error('OpenAI API Streaming Error:', errorMessage);
+        console.error('OpenAI API Streaming Error:', errorMessage);
       }
 
       // Provide helpful timeout-specific error message for streaming setup
@@ -753,7 +753,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
       totalTokens = encoding.encode(content).length;
       encoding.free();
     } catch (error) {
-      debugLogger.warn(
+      console.warn(
         'Failed to load tiktoken, falling back to character approximation:',
         error,
       );
@@ -815,7 +815,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
         ],
       };
     } catch (error) {
-      debugLogger.error('OpenAI API Embedding Error:', error);
+      console.error('OpenAI API Embedding Error:', error);
       throw new Error(
         `OpenAI API error: ${error instanceof Error ? error.message : String(error)}`,
       );


### PR DESCRIPTION
## Summary
- Force `temperature=1` and `top_p=0.95` for Kimi K2.5 models (Moonshot API rejects other values with `400 invalid temperature/top_p` error)
- Add unit tests for Kimi K2.5 and GPT-5 temperature enforcement
- Bump `@office-ai/aioncli-core` version to 0.24.5

## Background
Moonshot's Kimi K2.5 Thinking model enforces strict sampling parameter constraints:
- `temperature`: only `1` is allowed
- `top_p`: only `0.95` is allowed

Any other values result in a `400 Bad Request` error from the API.

## Test plan
- [x] Unit tests for Kimi K2.5 temperature=1 enforcement
- [x] Unit tests for GPT-5 temperature=1 enforcement
- [x] Manual testing with Kimi K2.5 model via AionUi — conversation succeeds