### PR TITLE
chore: bump @office-ai/aioncli-core version to 0.30.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@office-ai/aioncli-core",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "Gemini CLI Core",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

- Bump `@office-ai/aioncli-core` package version from `0.30.0` to `0.30.1`

## Test plan

- [ ] Verify `packages/core/package.json` version is `0.30.1`
- [ ] Run `npm run build` to confirm no build issues